### PR TITLE
handle shap multiple classes output

### DIFF
--- a/tests/test_shap_explainer.py
+++ b/tests/test_shap_explainer.py
@@ -6,14 +6,14 @@ from trelawney.shap_explainer import ShapExplainer
 
 
 def _do_explainer_test(explainer):
-    explanation = explainer.explain_local(pd.DataFrame([[5, 0.1], [95, -0.5]], columns=['real', 'fake']))
+    data = pd.DataFrame([[5, 0.1], [95, -0.5]], columns=['real', 'fake'])
+    explanation = explainer.explain_local(data)
     assert len(explanation) == 2
-    for single_explanation in explanation:
+    for single_explanation, data_row in zip(explanation, data.iterrows()):
         assert abs(single_explanation['real']) > abs(single_explanation['fake'])
 
-        # we need positive values as this feature is globally positivly corelated with the target and SHAP claims
-        # global consistency of it's explanations
-        # assert single_explanation['real'] > 0
+        # we need the values to be positive when the output is positive and negative when the output is negative
+        assert (single_explanation['real'] > 0) == (data_row[1]['real'] > 50)
 
 
 def test_shap_explainer_single(fake_dataset, fitted_logistic_regression):

--- a/trelawney/shap_explainer.py
+++ b/trelawney/shap_explainer.py
@@ -45,10 +45,10 @@ class ShapExplainer(BaseExplainer):
 
     def _get_shap_values(self, x_explain):
         shap_values = self._explainer.shap_values(x_explain.values)
-        if isinstance(self._model_to_explain, KerasClassifier):
-            # for nn, shap creates a list of shap values for every input layer in the NN,
-            # we assume one input layer
-            return shap_values[0]
+        if isinstance(shap_values, list):
+            # if we have a list this means there is one output per class, we take the positive class
+            # TODO class should be a parameter
+            return shap_values[1]
         return shap_values
 
     def explain_local(self, x_explain: pd.DataFrame, n_cols: Optional[int] = None) -> List[Dict[str, float]]:


### PR DESCRIPTION
there was a bug where shap would sometimes output a list of arrays for the positive and negative probabilities in which case we would bug out. I set the value to always output the positive class (element 1 of the list of array)